### PR TITLE
update to ansible 2.2.2.0 and alpine 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.4
 
 RUN \
   apk-install \
@@ -22,7 +22,7 @@ RUN echo "[local]" >> /etc/ansible/hosts && \
     echo "localhost" >> /etc/ansible/hosts
 
 RUN \
-  curl -fsSL https://github.com/ansible/ansible/releases/download/v2.0.0.1-1/ansible-2.0.0.1.tar.gz -o ansible.tar.gz && \
+  curl -fsSL https://releases.ansible.com/ansible/ansible-2.2.2.0.tar.gz -o ansible.tar.gz && \
   tar -xzf ansible.tar.gz -C ansible --strip-components 1 && \
   rm -fr ansible.tar.gz /ansible/docs /ansible/examples /ansible/packaging
 


### PR DESCRIPTION
Since 2.2.2.0 is the newest stable and this repository hasn't been updated in a while, I suggest updating to ansible 2.2.2.0. I also updated to alpine 3.4, which is the newest tag of the gliderlabs docker repo.

I didn't use the github.com link anymore, because that didn't include the core and extras modules, whereas the ansible release link does include those.