### PR TITLE
update ansible to 2.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gliderlabs/alpine:3.4
+ARG VERSION=2.7.2
 
 RUN \
   apk-install \
@@ -22,7 +23,7 @@ RUN echo "[local]" >> /etc/ansible/hosts && \
     echo "localhost" >> /etc/ansible/hosts
 
 RUN \
-  curl -fsSL https://releases.ansible.com/ansible/ansible-2.2.2.0.tar.gz -o ansible.tar.gz && \
+  curl -fsSL https://releases.ansible.com/ansible/ansible-${VERSION}.tar.gz -o ansible.tar.gz && \
   tar -xzf ansible.tar.gz -C ansible --strip-components 1 && \
   rm -fr ansible.tar.gz /ansible/docs /ansible/examples /ansible/packaging
 


### PR DESCRIPTION
I was trying to use this with the telnet module before I realized it was added in 2.4, so I figured I'd go ahead and update it to the latest release. I also extracted out the version to make it easier in the future, but I'm totally fine replacing it in-line